### PR TITLE
BUG: Fix path discovery in setup when using pip

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -62,7 +62,7 @@ def final_message(success=True):
         return
     print(msg)
 
-dir_name = os.path.dirname(__file__)
+dir_name = os.path.dirname(os.path.abspath(__file__))
 fname = os.path.join(dir_name, 'docs', 'index.rst')
 with io.open(fname, 'r') as f:
     long_desc = f.read()


### PR DESCRIPTION
The command `pip install` failed because dir_name was set to '', causing
os.chdir to raise an error (at least this is the case inside virtual
environments).  Using os.path.abspath, dir_name will return a valid path that
can be passed to os.chdir.
