### PR TITLE
Fix pip install where __file__ is set to 'setup.py'

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -62,7 +62,7 @@ def final_message(success=True):
         return
     print(msg)
 
-dir_name = os.path.dirname(__file__)
+dir_name = os.path.abspath(os.path.dirname(__file__))
 fname = os.path.join(dir_name, 'docs', 'index.rst')
 with io.open(fname, 'r') as f:
     long_desc = f.read()


### PR DESCRIPTION
This is a trivial fix, the pypi installation via pip fails because pip is changing to the build directory and then running 'setup.py', such that os.path.dirname(**file**) becomes '' .
