### PR TITLE
"xdress --debug" fails on Python3

### DIFF
--- a/xdress/plugins.py
+++ b/xdress/plugins.py
@@ -381,7 +381,7 @@ class Plugins(object):
                 if 0 < len(plugin_msg):
                     msg += sep
                     msg += plugin_msg
-            with io.open(os.path.join(rc.builddir, 'debug.txt'), 'a+b') as f:
+            with io.open(os.path.join(rc.builddir, 'debug.txt'), 'a+') as f:
                 f.write(msg)
             raise
         else:


### PR DESCRIPTION
While handling an exception, xdress tries to write _msg_ to _debug.txt_ in binary mode. But in Python 3, _str_ does not support Buffer interface, i.e., the string would need to be encoded first.

I assume it's OK to write the debug file in text mode instead.
