### PR TITLE
fix generation of class contructors

### DIFF
--- a/tests/cppproj/src/basics.h
+++ b/tests/cppproj/src/basics.h
@@ -48,6 +48,7 @@ typedef struct struct0 {
 class A {
  public:
   A() {};
+  A(int b) {};
   ~A() {};
   int a;
   virtual void call() {a=1;};

--- a/xdress/cythongen.py
+++ b/xdress/cythongen.py
@@ -432,8 +432,11 @@ def classcpppxd(desc, exceptions=True, ts=None):
 
     d['extra'] = desc.get('extra', {}).get('cpppxd', '')
     cpppxd = _cpppxd_class_template.format(**d)
+
+    extra = desc['extra']
     if 'srcpxd_filename' not in desc:
-        desc['srcpxd_filename'] = 'cpp_{0}.pxd'.format(d['name'].lower())
+        desc['srcpxd_filename'] = extra['srcpxd_filename']
+
     return cimport_tups, cpppxd
 
 
@@ -581,7 +584,7 @@ def classpxd(desc, classes=(), ts=None, max_callbacks=8):
     pars = ', '.join([ts.cython_cytype(p) for p in desc['parents']])
     d = {'parents': '('+pars+')' if pars else ''}
     name = desc['name']['tarname']
-    d['name'] = name if isinstance(name, basestring) else ts.cython_classname(name)[1]
+    d['name'] = ts.cython_classname(name)[1]
     max_callbacks = desc.get('extra', {}).get('max_callbacks', max_callbacks)
     mczeropad = int(math.log10(max_callbacks)) + 1
 
@@ -624,7 +627,7 @@ def classpxd(desc, classes=(), ts=None, max_callbacks=8):
             fplines.append("cdef unsigned int _current_{0}_vtab_i".format(apyname))
 
     if len(fplines) > 0:
-        fplines.append("cdef unsigned int _MAX_CALLBACKS_" + desc['name']['tarname'])
+        fplines.append("cdef unsigned int _MAX_CALLBACKS_" + d['name'])
 
     d['body'] = indent(body or ['pass'])
     d['function_pointer_block'] = '\n'.join(fplines)
@@ -1226,7 +1229,7 @@ def classpyx(desc, classes=None, ts=None, max_callbacks=8):
          'namespace': desc['namespace'],
          }
     name = desc['name']['tarname']
-    d['name'] = name if isinstance(name, basestring) else ts.cython_classname(name)[1]
+    d['name'] = ts.cython_classname(name)[1]
     class_doc = desc.get('docstrings', {}).get('class', nodocmsg.format(desc['name']))
     d['class_docstring'] = indent('\"\"\"{0}\"\"\"'.format(class_doc))
 
@@ -1288,7 +1291,7 @@ def classpyx(desc, classes=None, ts=None, max_callbacks=8):
         if any([a[1] is None or a[1][0] is None for a in margs]):
             continue
         if 1 < methcounts[mname]:
-            mname_mangled = "_{0}_{1}_{2:0{3}}".format(desc['name'], mcyname,
+            mname_mangled = "_{0}_{1}_{2:0{3}}".format(d['name'], mcyname,
                     currcounts[mname], int(math.log(methcounts[mname], 10)+1)).lower()
         else:
             mname_mangled = mcyname
@@ -1298,12 +1301,12 @@ def classpyx(desc, classes=None, ts=None, max_callbacks=8):
             ts.cython_import_tuples(a[1], import_tups)
             ts.cython_cimport_tuples(a[1], cimport_tups)
         minst_name, mcname = _method_instance_names(desc, classes, mkey, mrtn, ts)
-        if mcname != desc['name']:
+        if mcname != d['name']:
             ts.cython_import_tuples(mcname, import_tups)
             ts.cython_cimport_tuples(mcname, cimport_tups)
         if mrtn is None:
             # this must be a constructor
-            if mname not in (desc['name'], '__init__'):
+            if mname not in (d['name'], '__init__'):
                 continue  # skip destuctors
             if 1 == methcounts[mname]:
                 mname_mangled = '__init__'
@@ -1313,7 +1316,7 @@ def classpyx(desc, classes=None, ts=None, max_callbacks=8):
             construct = desc['construct']
             if construct == 'struct':
                 cimport_tups.add(('libc.stdlib', 'malloc'))
-            clines += _gen_constructor(mcyname, mname_mangled, desc['name'], margs,
+            clines += _gen_constructor(mcyname, mname_mangled, d['name'], margs,
                         ts, doc=mdoc, srcpxd_filename=desc['srcpxd_filename'],
                         inst_name=minst_name, construct=construct)
             if 1 < methcounts[mname] and currcounts[mname] == methcounts[mname]:


### PR DESCRIPTION
This needs review.

Every use of desc['name'] in xdress/cython.py is probably suspect.

Fixes errors such as the following

```
Error compiling Cython file:
------------------------------------------------------------
...


    def __init__(self):
        """Untemplated(self)
        """
        self._inst = new cpp_untemplated.Untemplated()
                        ^
------------------------------------------------------------

Error compiling Cython file:
------------------------------------------------------------
...


    def __init__(self):
        """Untemplated(self)
        """
        self._inst = new cpp_untemplated.{'tarbase': 'basics', 'tarname': 'Untemplated', 'language': 'c++', 'srcname': 'Untemplated', 'sidecars': ('src/basics.py',), 'incfiles': ('basics.h',), 'srcfiles': ('src/basics.cpp', 'src/basics.h')}()
                                        ^
------------------------------------------------------------
```
