### PR TITLE
fix generation of templated, inheritated cppclass

### DIFF
--- a/tests/cppproj/src/basics.h
+++ b/tests/cppproj/src/basics.h
@@ -93,6 +93,12 @@ class TClass0 {
   template <class U> int whatstheanswer(U u){return 42;};
 };
 
+
+template <class T> class TClass2 : public TClass0<T> {
+  public:
+    T bob;
+};
+
 template <class T>
 class TClass1 {
  public:
@@ -192,6 +198,8 @@ std::vector<float> vf;
 std::vector< std::vector<float> > vvf;
 TClass0<float> smeflts;
 TClass1<float> spflts;
+TClass0<float> smeflts0;
+TClass2<float> spflts2;
 
 }; // namespace cppproj
 

--- a/tests/cppproj/xdressrc.py
+++ b/tests/cppproj/xdressrc.py
@@ -119,6 +119,8 @@ classes = [
     apiname('Untemplated', **_inbasics), 
     apiname('ThreeNums', tarbase='pybasics', **_inbasics),
     apiname('*', **_indiscovery),
+    apiname(('TClass0', 'float32'), **_inbasics), 
+    apiname(('TClass2', 'float32'), **_inbasics), 
     ]
 
 del os

--- a/xdress/cythongen.py
+++ b/xdress/cythongen.py
@@ -95,6 +95,8 @@ def cpppxd_sorted_names(mod, ts):
     for name in clssort:
         desc = mod[name]
         othercls[name] = set()
+        for pitem in desc['parents']:
+            _addotherclsnames(pitem, classes, name, othercls, ts)
         for aname, atype in desc['attrs'].items():
             _addotherclsnames(atype, classes, name, othercls, ts)
         for mkey, mtype in desc['methods'].items():
@@ -318,7 +320,7 @@ def funccpppxd(desc, exceptions=True, ts=None):
 _cpppxd_class_template = \
 """cdef extern from "{header_filename}" {namespace}:
 
-    cdef {construct_kind} {name}{parents}{alias}:
+    cdef {construct_kind} {name}{alias}{parents}:
         # constructors
 {constructors_block}
 


### PR DESCRIPTION
According to the cython parser, alias must appear before parents.
Parents also need to be take in to account when sorting cpppxd definitions
