### PR TITLE
Added global rc files

### DIFF
--- a/xdress/main.py
+++ b/xdress/main.py
@@ -227,6 +227,7 @@ def main():
         globalrcdict = {}
         exec_file(globalrc, globalrcdict, globalrcdict)
         rc._update(globalrcdict)
+    rc._update(rcdict)
     rc._update([(k, v) for k, v in ns.__dict__.items()])
     plugins.setup()
     plugins.execute()


### PR DESCRIPTION
Notably the special 'plugins' and 'rc' run control parameters will be skipped if they show up in the global run control files.  This is done for speed of argparsing.  These seems reasonable since these parameters dictate how any specific xdress should be performed and it doesn't make sense to set them globally anyways.  Other than that, all parameters are handled normally. 

All of the following files are searched in order of increasing precedence: `$HOME/.xdressrc`, `$HOME/.xdressrc.py`, `$HOME/.config/xdressrc`, `$HOME/.config/xdressrc.py`
