### PR TITLE
Fixes clang autodescribe to support boolean template arguments and string literal function default arguments

### DIFF
--- a/tests/test_autodescribe.py
+++ b/tests/test_autodescribe.py
@@ -31,6 +31,15 @@ def exp_base_desc(parser):
             'type': base,
             }
 
+exp_point_desc = {
+    'name': ('Point', True, 0),
+    'namespace': 'xdress',
+    'parents': [],
+    'construct': 'class',
+    'attrs': {},
+    'methods': {(('Point', True),): None, (('~Point', True),): None},
+    'type': ('Point', True, 0)}
+
 exp_toaster_desc = {
     'name': 'Toaster',
     'namespace': 'xdress',
@@ -45,6 +54,7 @@ exp_toaster_desc = {
         },
     'methods': {
         ('Toaster', ('slices', 'int32', 7), ('flag', 'bool', False)): None,
+        ('Toaster', ('d', 'float64'), ('arg', 'str', '"\\n"' )): None,
         ('~Toaster',): None,
         ('make_toast', ('when', 'str'), ('nslices', 'uint32', 1), ('dub', 'float64', 3e-8)): 'int32',
         ('templates', ('strange', ('Base', 'int32', 3, 0))): ('Base', 'float32', 0, 0),
@@ -158,6 +168,7 @@ def test_describe_cpp():
     ts.register_classname('Toaster', 'toaster', 'toaster', 'cpp_toaster')
     def check(parser):
         goals = (('class',('Base','int32',7,0),exp_base_desc(parser)),
+                 ('class', ('Point', True, 0), exp_point_desc),
                  ('class','Toaster',exp_toaster_desc),
                  ('func','simple',exp_simple_desc),
                  ('func','twice',exp_twice_desc), # Verify that we pick up parameter names from definitions

--- a/tests/toaster.h
+++ b/tests/toaster.h
@@ -21,11 +21,21 @@ template<class T, int i=0> struct Base {
   void base(int a=1);
 };
 
+// boolean template params
+template< bool B = false>
+class Point {};
+
+template<>
+class Point< true > {};
+
+
 // Toaster class
 class Toaster : Base<int,6+1> {
 public:
   // Toaster Constructors
   Toaster(int slices=7, bool flag=false);
+  //constructor with with string literal default arg
+  Toaster(double d, std::string arg = "\n");
   ~Toaster();
 
   // Public fields

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -119,6 +119,7 @@ def show_diff(a,b,key=None):
 
 def assert_equal_or_diff(obs, exp):
     try:
+        assert_equal.im_class.maxDiff = None
         assert_equal(obs, exp)
     except:
         key = '\n\n# only expected = {0}, only computed = {1}\n'


### PR DESCRIPTION
gccxml doesn't like the new tests, but clang seems to pass

```
ERROR: test_autodescribe.test_describe_cpp('gccxml',)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/tewk/xdress/tests/test_autodescribe.py", line 181, in check
    clang_includes=clang_includes)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/autodescribe.py", line 2087, in describe
    clang_includes=clang_includes)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/autodescribe.py", line 382, in gccxml_describe
    describer = describers[kind](name, root, onlyin=onlyin, ts=ts, verbose=verbose)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/autodescribe.py", line 825, in __init__
    self.desc['type'] = ts.canon(name)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/utils.py", line 705, in __call__
    cache[key] = self.meth(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/typesystem.py", line 1438, in canon
    return (self.canon(t0), last_val)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/utils.py", line 705, in __call__
    cache[key] = self.meth(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/typesystem.py", line 1399, in canon
    _raise_type_error(t)
  File "/usr/local/lib/python2.7/dist-packages/xdress-0.4_dev-py2.7.egg/xdress/typesystem.py", line 3161, in _raise_type_error
    raise TypeError("type of {0!r} could not be determined".format(t))
TypeError: type of 'Point' could not be determined

----------------------------------------------------------------------
Ran 393 tests in 29.919s
```
