### PR TITLE
Fix clang frontend for python 3

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -11,6 +11,16 @@ sys.path.insert(0, '')
 import xdress.version
 sys.path.pop(0)
 
+# Fix bug in distutils for python 3
+if sys.version_info[0] >= 3:
+    def decode(s):
+        return s if isinstance(s,str) else bytes.decode(s)
+    import distutils.spawn
+    old_spawn_posix = distutils.spawn._spawn_posix
+    def hack_spawn_posix(cmd, search_path=1, verbose=0, dry_run=0):
+        return old_spawn_posix(list(map(decode, cmd)), search_path, verbose, dry_run)
+    distutils.spawn._spawn_posix = hack_spawn_posix
+
 INFO = {
     'version': xdress.version.xdress_version,
 }

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -121,7 +121,6 @@ def show_diff(a,b,key=None):
 
 def assert_equal_or_diff(obs, exp):
     try:
-        assert_equal.im_class.maxDiff = None
         assert_equal(obs, exp)
     except:
         key = '\n\n# only expected = {0}, only computed = {1}\n'

--- a/xdress/autodescribe.py
+++ b/xdress/autodescribe.py
@@ -201,6 +201,7 @@ from hashlib import md5
 from numbers import Number
 from pprint import pprint, pformat
 from warnings import warn
+from functools import reduce
 
 if os.name == 'nt':
     import ntpath
@@ -1352,7 +1353,7 @@ def clang_str_location(loc):
 def clang_describe_functions(funcs):
     """Describe the function at the given clang AST nodes.  If more than one
     node is given, we verify that they match and find argument names where we can."""
-    descs = map(clang_describe_function,funcs)
+    descs = tuple(map(clang_describe_function,funcs))
     if len(descs)==1:
         return descs[0]
     def merge(d0,d1):
@@ -1388,7 +1389,7 @@ def clang_describe_functions(funcs):
             for i in xrange(j):
                 try:
                     merge(descs[i],descs[j])
-                except ValueError,e:
+                except ValueError as e:
                     from pprint import pprint
                     pprint(descs[i])
                     pprint(descs[j])
@@ -1509,11 +1510,12 @@ def clang_describe_template_arg(arg, loc):
     try:
         # ast.literal_eval isn't precisely correct, since there are Python
         # literals which aren't valid C++, but it should be close enough.
-        return ast.literal_eval(arg.spelling.strip())
+        s = arg.spelling.strip()
+        return ast.literal_eval(s)
     except:
         pass
     try:
-        return _clang_expressions[arg.spelling]
+        return _clang_expressions[s]
     except KeyError:
         raise NotImplementedError('template argument kind {0} at {1}'
             .format(arg.kind.name, clang_str_location(loc)))

--- a/xdress/clang/.gitignore
+++ b/xdress/clang/.gitignore
@@ -1,1 +1,1 @@
-libclang.so
+libclang*.so

--- a/xdress/clang/src/xdress-clang.cpp
+++ b/xdress/clang/src/xdress-clang.cpp
@@ -8,7 +8,21 @@ void XDRESS_FATAL(const char* message) {
   ::abort();
 }
 
+#if PY_MAJOR_VERSION >= 3
+
+PyMODINIT_FUNC PyInit_libclang(void) {
+  static struct PyModuleDef def = {
+    PyModuleDef_HEAD_INIT,
+    "libclang"
+  };
+  return PyModule_Create(&def);
+}
+
+#else // Python 2.x
+
 PyMODINIT_FUNC initlibclang(void) {
   Py_InitModule("libclang", 0);
 }
+
+#endif
 #endif


### PR DESCRIPTION
This should fix the xdress side of the clang python 3 issues.  You'll also need to pull from https://github.com/girving/clang/tree/xdress to get some fixes on the libclang side.

Unfortunately, the integration tests now segfault if both clang and gccxml are run, though not if only clang is run.
