### PR TITLE
bug_default_function_arguements

### DIFF
--- a/tests/cppproj/src/basics.h
+++ b/tests/cppproj/src/basics.h
@@ -52,6 +52,7 @@ class A {
   ~A() {};
   int a;
   virtual void call() {a=1;};
+  void writeBCOutput(std::string file_name, std::string linefeed = "\n") const {}
 };
 
 class B : public A {


### PR DESCRIPTION
This parses just fine, but generates bad cython code

```
Error compiling Cython file:
------------------------------------------------------------
...
        no docstring for call, please file a bug report!"""
        (<cpp_basics.A *> self._inst).call()


    def writeBCOutput(self, file_name, linefeed=
):
^
------------------------------------------------------------
```

It looks like we are injecting a literal \n instead of "\n"
could ast.literal_eval be the problem ??
