### PR TITLE
autodescribe support for variables

### DIFF
--- a/tests/test_autodescribe.py
+++ b/tests/test_autodescribe.py
@@ -115,6 +115,9 @@ exp_toaster_desc = {
         ('reference', ('a', ('int32', '&')), ('b', (('int32', 'const'), '&'))): {
             'return': ('int32', '&'),
             'defaults': ((Arg.NONE, None), (Arg.NONE, None))},
+        ('variable_decl', ('slices', 'int32')): {
+            'return': 'void',
+            'defaults': ((Arg.VAR, 'default_slices'), )},
         },
     'type': 'Toaster',
     }
@@ -133,6 +136,42 @@ exp_conflict_desc = {
     'name': 'conflict',
     'namespace': 'xdress',
     'signatures': {('conflict', ('good', 'int32')): {'return': 'void', 'defaults': ((Arg.NONE, None),)}}}
+
+exp_default_slices = {
+    'name': 'default_slices',
+    'namespace': 'xdress',
+    'type': ('int32', 0)
+}
+
+exp_const_default_slices = {
+    'name': 'const_default_slices',
+    'namespace': 'xdress',
+    'type': (('int32', 'const'), 0)
+}
+
+exp_default_slices_pointer = {
+    'name': 'default_slices_pointer',
+    'namespace': 'xdress',
+    'type': (('int32', '*'), 0)
+}
+
+exp_const_default_slices_pointer = {
+    'name': 'const_default_slices_pointer',
+    'namespace': 'xdress',
+    'type': ((('int32', 'const'), '*'), 0)
+}
+
+exp_var_int_array = {
+    'name': 'var_int_array',
+    'namespace': 'xdress',
+    'type': ('int32', 2)
+}
+
+exp_const_int_array = {
+    'name': 'const_int_array',
+    'namespace': 'xdress',
+    'type': (('int32', 'const'), 2)
+}
 
 def exp_lasso_desc(n):
     lasso_name = ('lasso', n, 'int32', 'float32')
@@ -234,7 +273,12 @@ def test_describe_cpp():
                  ('class', 'Default', exp_default_desc),
                  ('class', 'NoDefaultBase', exp_nodefault_base_desc),
                  ('class', 'NoDefault', exp_nodefault_desc),
-                 ('var', 'Choices', exp_choices_desc))
+                 ('var', 'Choices', exp_choices_desc),
+                 ('var', 'default_slices', exp_default_slices),
+                 ('var', 'const_default_slices', exp_const_default_slices),
+                 ('var', 'const_default_slices_pointer', exp_const_default_slices_pointer),
+                 ('var', 'var_int_array', exp_var_int_array),
+                 ('var', 'const_int_array', exp_const_int_array))
         for kind, name, exp in goals:
             obs = ad.describe(fname, name=name, kind=kind, parsers=parser, 
                               builddir=buildbase + '-' + parser, verbose=False, 

--- a/tests/toaster.h
+++ b/tests/toaster.h
@@ -13,6 +13,14 @@
 
 namespace xdress {
 
+// variables
+int default_slices=8;
+const int const_default_slices=8;
+int * default_slices_pointer=&default_slices;
+const int * const_default_slices_pointer=&default_slices;
+int var_int_array [2];
+const int const_int_array [2] = {1,2};
+
 template<class T, int i=0> struct Base {
   // Fields in template classes
   int field;
@@ -55,6 +63,8 @@ public:
   const int const_(const int c) const;
   int* pointers(int* a, const int* b, int* const c, const int* const d);
   int& reference(int& a, const int& b);
+  void variable_decl(int slices=default_slices);
+
 
 private:
   // Should not be described

--- a/xdress/autodescribe.py
+++ b/xdress/autodescribe.py
@@ -708,6 +708,8 @@ class GccxmlBaseDescriber(object):
                 islit = True
             except ValueError:
                 islit = False  # Leave default as is
+                # trim namespaces from variables at the moment
+                default = default.split('::')[-1]
             argkind = (Arg.LIT if islit else Arg.VAR, default)
         self._currfuncsig.append(arg)
         self._currargkind.append(argkind)
@@ -755,6 +757,8 @@ class GccxmlBaseDescriber(object):
         if isinstance(baset, basestring):
             return (baset, pred)
         last = baset[-1]
+        if pred == 'const' and isinstance(last, int):
+            return ((baset[0], pred), last)
         if last in self._predicates or isinstance(last, int):
             return (baset, pred)
         else:
@@ -764,9 +768,8 @@ class GccxmlBaseDescriber(object):
         """visits an array type and maps it to a '*' refinement type."""
         self._pprint(node)
         baset = self.type(node.attrib['type'])
-        # FIXME something involving the min, max, and/or size
-        # attribs needs to also go here.
-        t = self._add_predicate(baset, '*')
+        size = int(node.get('max').rstrip('u')) + 1
+        t = self._add_predicate(baset, size)
         return t
 
     def visit_functiontype(self, node):
@@ -813,7 +816,7 @@ class GccxmlBaseDescriber(object):
             t = self._add_predicate(t, 'restrict')
         return t
 
-    def type(self, id):
+    def type(self, id, var=False):
         """Resolves the type from its id and information in the root element tree."""
         node = self._root.find(".//*[@id='{0}']".format(id))
         tag = node.tag.lower()
@@ -824,6 +827,9 @@ class GccxmlBaseDescriber(object):
             self._level += 1
             t = meth(node)
             self._level -= 1
+            # FIXME: should add a isscalar/isvector method to the typesystem?
+            if var and (isinstance(t, basestring) or not isinstance(t[1], int)):
+                t = (t, 0)
         return t
 
     def visit_namespace(self, node):
@@ -983,7 +989,7 @@ class GccxmlVarDescriber(GccxmlBaseDescriber):
                 ns = self.context(n.attrib['context'])
                 if ns is not None and ns != "::":
                     self.desc['namespace'] = ns
-                self.desc['type'] = self.type(n.attrib['type'])
+                self.desc['type'] = self.type(n.attrib['type'], var=True)
                 break
             else:
                 msg = ("{0} autodescribing failed: found variable in {1!r} but "
@@ -1292,7 +1298,7 @@ def clang_find_function(tu, name, ts, namespace=None, filename=None, onlyin=None
 def clang_find_var(tu, name, ts, namespace=None, filename=None, onlyin=None):
     """Find the node for a given var."""
     assert isinstance(name, basestring)
-    kinds = CursorKind.ENUM_DECL,
+    kinds = (CursorKind.ENUM_DECL, CursorKind.VAR_DECL)
     decls = clang_find_decls(tu, name, kinds=kinds, onlyin=onlyin, namespace=namespace)
     decls = list(set(c.get_definition() or c for c in decls)) # Use definitions if available
     if len(decls)==1:
@@ -1401,6 +1407,16 @@ def clang_describe_var(var):
     if var.kind == CursorKind.ENUM_DECL:
         return {'name': var.spelling, 'namespace': clang_parent_namespace(var),
                 'type': clang_describe_enum(var)}
+    elif var.kind == CursorKind.VAR_DECL:
+        if var.type.kind == TypeKind.CONSTANTARRAY:
+            array_size = var.type.get_array_size()
+            typ = clang_describe_type(var.type.get_array_element_type(), var.location)
+        else:
+            typ = clang_describe_type(var.type, var.location)
+            array_size = 0
+        typ = (typ, array_size)
+        return {'name': var.spelling, 'namespace': clang_parent_namespace(var),
+                'type': typ}
     else:
         raise NotImplementedError('var kind {0}: {1}'.format(var.kind, var.spelling))
 
@@ -1584,6 +1600,8 @@ def clang_describe_expression(exp):
     if exp.referenced:
         exp = exp.referenced
     if exp.kind == CursorKind.ENUM_CONSTANT_DECL:
+        return Arg.VAR, s.strip()
+    if exp.kind == CursorKind.VAR_DECL:
         return Arg.VAR, s.strip()
     # Nothing worked, so bail
     kind = exp.kind.name


### PR DESCRIPTION
This is a much cleaner patch of some of the work in #156.

It adds tests for variables in autodescribe and the clang implementation.

@scopatz can you have a quick look and check the types in the tests are correct.  I'm not certain where a `const int foo[2]` is a `(('int32', 'const'), 2)` or `(('int32', 2) 'const')`.  In fact, those seem like the same type!
