### PR TITLE
Made debug output overwrite `debug.txt` instead of appending.

### DIFF
--- a/xdress/plugins.py
+++ b/xdress/plugins.py
@@ -403,7 +403,7 @@ class Plugins(object):
                 if 0 < len(plugin_msg):
                     msg += sep
                     msg += plugin_msg
-            with io.open(os.path.join(rc.builddir, 'debug.txt'), 'a+') as f:
+            with io.open(os.path.join(rc.builddir, 'debug.txt'), 'wt') as f:
                 f.write(msg)
             if err != 0:
                 raise


### PR DESCRIPTION
See the discussion on the [mailing list](https://groups.google.com/forum/#!msg/xdress/E9gA9X0YDus/EFITq-FZ9KQJ) for this feature request.
