### PR TITLE
fixed fail on processing headers with substring 'type' in their names

### DIFF
--- a/tests/cproj/cproj/CMakeLists.txt
+++ b/tests/cproj/cproj/CMakeLists.txt
@@ -18,3 +18,7 @@ target_link_libraries(pybasics cproj_basics)
 # discovery
 cython_add_module(discovery discovery.pyx)
 target_link_libraries(discovery cproj_discovery)
+
+# cproj_types
+cython_add_module(cproj_types cproj_types.pyx)
+target_link_libraries(cproj_types cproj_cproj_types)

--- a/tests/cproj/cproj/tests/test_cproj_types.py
+++ b/tests/cproj/cproj/tests/test_cproj_types.py
@@ -1,0 +1,17 @@
+from __future__ import print_function
+import sys
+
+from nose.tools import assert_equal, assert_true
+from numpy.testing import assert_array_equal, assert_array_almost_equal
+
+from cproj import cproj_types
+
+def test_type_substr_in_header():
+    x = cproj_types.cproj_test_struct_s()
+    assert_true(x is not None)
+    x.chr = chr(42)
+    x.byte = chr(13)
+    assert_equal(x.chr, chr(42))
+    y = cproj_types.get_cproj_defaults()
+    assert_equal(x.chr, y.chr)
+    assert_equal(x.byte, y.byte)

--- a/tests/cproj/src/CMakeLists.txt
+++ b/tests/cproj/src/CMakeLists.txt
@@ -17,6 +17,13 @@ set_target_properties(cproj_discovery PROPERTIES
 target_link_libraries(cproj_discovery)
 install_lib(cproj_discovery)
 
+# cproj_types
+add_library(cproj_cproj_types cproj_types.c)
+set_target_properties(cproj_cproj_types PROPERTIES
+                      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/cproj/lib")
+target_link_libraries(cproj_cproj_types)
+install_lib(cproj_cproj_types)
+
 # Print include dir
 get_property(inc_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
 message("-- C_INCLUDE_PATH for ${CMAKE_CURRENT_SOURCE_DIR}: ${inc_dirs}")

--- a/tests/cproj/src/cproj_types.c
+++ b/tests/cproj/src/cproj_types.c
@@ -1,0 +1,11 @@
+#include "cproj_types.h"
+
+static cproj_test_struct_t test_struct = {
+	.chr = 42,
+	.byte = 13,
+};
+
+cproj_test_struct_t get_cproj_defaults()
+{
+	return test_struct;
+}

--- a/tests/cproj/src/cproj_types.h
+++ b/tests/cproj/src/cproj_types.h
@@ -1,0 +1,14 @@
+#if !defined(_CPROJ_TYPES_)
+#define _CPROJ_TYPES_
+
+typedef char cproj_char_t;
+typedef unsigned char cproj_byte_t;
+
+typedef struct cproj_test_struct_s {
+	cproj_char_t chr;
+	cproj_byte_t byte;
+} cproj_test_struct_t;
+
+cproj_test_struct_t get_cproj_defaults();
+
+#endif

--- a/tests/cproj/xdressrc.py
+++ b/tests/cproj/xdressrc.py
@@ -5,8 +5,7 @@ package = 'cproj'
 packagedir = 'cproj'
 includes = ['src']
 
-plugins = ('xdress.autoall', 'xdress.pep8names', 'xdress.cythongen', 
-           'xdress.extratypes')
+plugins = ('xdress.autoall', 'xdress.cythongen', 'xdress.extratypes')
 
 extra_types = 'cproj_extra_types'  # non-default value
 
@@ -17,10 +16,15 @@ _inbasics = {'srcfiles': _fromsrcdir('basics*'),
 _indiscovery = {'srcfiles': _fromsrcdir('discovery*'),
                 'incfiles': 'discovery.h',
                 }
+_incprojtypes = {'srcfiles': _fromsrcdir('cproj_types*'),
+                 'incfiles': 'cproj_types.h',
+                 'language': 'c',
+                }
 
 variables = [
     apiname('PersonID', tarbase='pybasics', **_inbasics),
     apiname('*', **_indiscovery),
+    apiname('*', tarbase='cproj_types', **_incprojtypes),
     ]
 
 functions = [
@@ -36,6 +40,7 @@ functions = [
     apiname('func4', tarbase='pybasics', **_inbasics),
     apiname('call_threenums_op_from_c', tarbase='pybasics', **_inbasics),
     apiname('*', **_indiscovery),
+    apiname('*', tarbase='cproj_types', **_incprojtypes),
     ]
 
 classes = [
@@ -43,6 +48,7 @@ classes = [
     apiname('SharedSpace', tarbase='pybasics', **_inbasics),
     apiname('ThreeNums', tarbase='pybasics', **_inbasics),
     apiname('*', **_indiscovery),
+    apiname('*', tarbase='cproj_types', **_incprojtypes),
     ]
 
 del os

--- a/xdress/autodescribe.py
+++ b/xdress/autodescribe.py
@@ -1832,11 +1832,6 @@ class PycparserBaseDescriber(PycparserNodeVisitor):
         if node.value is None:
             if len(self._currenum) == 0:
                 value = 0
-            elif isinstance(self._currenum[-1][-1], pycparser.c_ast.ID):
-                for elem in self._currenum:
-                    if elem[0] == self._currenum[-1][-1].name:
-                        value = elem[1]
-                        break
             else:
                 value = self._currenum[-1][-1] + 1
         elif isinstance(node.value, pycparser.c_ast.Constant):


### PR DESCRIPTION
Hi @scopatz. We are using xdress to create python bindings for sdk written in 'c' and faced with issue when xdress fails on processing 'c' headers with 'type' in their names (e.g. we have types.h in our sdk). In such case module description is considered as variable description. I added additional verification for it, but not sure that it's right solution.
