### PR TITLE
 Explicitly mention available parsers upon Errors and on CLI #272

### DIFF
--- a/xdress/astparsers.py
+++ b/xdress/astparsers.py
@@ -448,7 +448,10 @@ class ParserPlugin(Plugin):
                       "or apiname format"),
         'classes': ("A list of class names in sequence, mapping, "
                     "or apiname format"),
-        'parsers': "Parser(s) name, list, or dict",
+        'parsers': ("Parser(s) name, list, or dict, \n"
+                   "Options include \n"
+                   "     c: ['pycparser', 'clang', 'gccxml'] \n"
+                   "     c++:['clang', 'gccxml', 'pycparser']"),
         'clear_parser_cache_period': ("Number of parser calls to perform before "
                                       "clearing the internal cache.  This prevents "
                                       "nasty memory overflow issues."),


### PR DESCRIPTION
Hi @scopatz This final pull request adds the actual parser implementations to the CLI --help function.
Apologies for missing this last time around.
